### PR TITLE
Add CD definition

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: CD
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest        
+    defaults:
+      run:
+        working-directory: optumdocs    
+    steps:      
+      - uses: actions/checkout@v2
+      - run: ls
+      - name: Install
+        run: yarn install --no-lockfile
+      - name: Build
+        run: yarn build
+      - uses: actions/upload-artifact@master
+        with:
+          name: docsite
+          # working-directory doesn't appear to be honored when using `uses`
+          path: optumdocs/build/
+  deploy:
+    needs: [build]
+    runs-on: ubuntu-latest  
+    steps:
+      - uses: actions/download-artifact@master
+        with:
+          name: docsite
+          path: docsite
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docsite
+          # This is my personal taste, it can always be removed:
+          force_orphan: true


### PR DESCRIPTION
This is a stab at addressing #21 

## Notes

The build can be seen running at the following URL: https://github.com/JoshuaTheMiller/optum.github.io/actions/runs/307731938.

**My** deployed version of this site looks somewhat funky as I am not changing the expected root directory of it during _my_ build. In other words, it is expecting the site to be hosted on `joshuathemiller.github.io`, not `joshuathemiller.github.io/optum.github.io` (the actual path, since it does not match my GitHub name).

### When

This will run when the branch that is _currently_ named `master` is pushed to.

### Condensing

All steps could most likely be moved under 1 `job`. Personally, I like seeing separate build and release items for Action definitions though:

![image](https://user-images.githubusercontent.com/4266541/96070278-7dcced80-0e65-11eb-9f83-0246ac3c042f.png)

### Orphaning of gh-pages branch

Additionally, this actually orphans the `gh-pages` branch on every deploy (in essence, only the latest commit will be kept in that branch). This was done as I _personally_ do not see a lot of value in keeping the history of that branch around. If we wanted to keep a deployment artifact history, `releases` could be leveraged.

![image](https://user-images.githubusercontent.com/4266541/96070247-6d1c7780-0e65-11eb-8245-8e820c4267a5.png)
