### PR TITLE
Resolve issue 52 - Typo on Guilds page

### DIFF
--- a/optumdocs/docs/Guilds.md
+++ b/optumdocs/docs/Guilds.md
@@ -11,5 +11,5 @@ sidebar_label: Guilds
 | Compute            |                                           Softwared across the full stack spectrum                                            | Ben Woodring             |
 | Data/ML/AI         |         Wrangling transformation and custom ML/AI solutions pertinent for managed data well and healthcare innovation         | Kevin Muse, Ben Woodring |
 | Sourcing           |       Best Practices and process improvements in service of code and development. Developer and open source experience        | Devin Houde, Amy Schoen  |
-| Clinical Solutions | An open source industry differentiator. Exploring/building technological solutions that advances the global healthcare agenda | Keven Muse               |
+| Clinical Solutions | An open source industry differentiator. Exploring/building technological solutions that advances the global healthcare agenda | Kevin Muse               |
 | Security           |                    Security solutions and security guidance for how we open source across the organization                    | Eric Hart, Devin Houde   |


### PR DESCRIPTION
Resolving issue #52 

On the Guilds page (https://opensource.optum.com/docs/guilds) Kevin Muse is referenced as Keven Muse in the Clinical Solutions line. This PR corrects his name to Kevin.